### PR TITLE
fix: stop duplicate keys from happening

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,7 @@ require github.com/stretchr/testify v1.10.0
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/veqryn/slog-dedup v0.5.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	modernc.org/b/v2 v2.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,11 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/veqryn/slog-dedup v0.5.0 h1:2pc4va3q8p7Tor1SjVvi1ZbVK/oKNPgsqG15XFEt0iM=
+github.com/veqryn/slog-dedup v0.5.0/go.mod h1:/iQU008M3qFa5RovtfiHiODxJFvxZLjWRG/qf/zKFHw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+modernc.org/b/v2 v2.1.0 h1:kMD/G43EYnsFJI/0qK1F1X659XlSs41bp01MUDidHC0=
+modernc.org/b/v2 v2.1.0/go.mod h1:fQhHWDXrchyUSLjQYCslV/4uw04PW1LeiZ25D4SNmeo=

--- a/slogger.go
+++ b/slogger.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+
+	slogdedup "github.com/veqryn/slog-dedup"
 )
 
 const (
@@ -60,9 +62,9 @@ func NewLogger(loggerOpts *LoggerOpts, handlerOpts ...func(o *slog.HandlerOption
 	}
 
 	if strings.ToLower(loggerOpts.mode) == ModeJSON {
-		return slog.New(slog.NewJSONHandler(loggerOpts.destination, hOpts))
+		return slog.New(slogdedup.NewOverwriteHandler(slog.NewJSONHandler(loggerOpts.destination, hOpts), nil))
 	}
-	return slog.New(slog.NewTextHandler(loggerOpts.destination, hOpts))
+	return slog.New(slogdedup.NewOverwriteHandler(slog.NewTextHandler(loggerOpts.destination, hOpts), nil))
 }
 
 func WithSource() func(o *slog.HandlerOptions) {


### PR DESCRIPTION
Currently the same key can be duplicated in the log line, this is confusing so this will fix this going forwards